### PR TITLE
Fix the last cell not being properly picked by SpreadsheetExtractionAlgorithm

### DIFF
--- a/.github/workflows/dotnet-mac.yml
+++ b/.github/workflows/dotnet-mac.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-
     runs-on: macos-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core

--- a/.github/workflows/dotnet-windows.yml
+++ b/.github/workflows/dotnet-windows.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# tabula-sharp
+# tabula-sharp fix https://github.com/BobLd/tabula-sharp/issues/25
+
+THIS REPOSITORY CONTAINS THE v.0.1.3 version of lib with https://github.com/BobLd/tabula-sharp/issues/25 fixed and will be deleted once mantainer releases the library version with proper fix. 
+
 `tabula-sharp` is a library for extracting tables from PDF files — it is a port of [tabula-java](https://github.com/tabulapdf/tabula-java)
 
 ![Windows](https://github.com/BobLd/tabula-sharp/workflows/Windows/badge.svg)


### PR DESCRIPTION
https://github.com/BobLd/tabula-sharp/issues/25 - PR for the Issue mention in this issue.

We can pick the contents of SpreadsheetExtractionAlgorithm horizontalR collection line 116 and see that the first boundry is the only one with X coordinates in reverse order. 

That bottom boundary of the page was inserted with reversed X coordinates. This has caused the SpreadsheetExtractionAlgorithm to fail to properly pick last line cells on some of the PDFs.

