### PR TITLE
Investigating [BUG] - Stream: Area detection hangs on PDF page #30

### DIFF
--- a/Tabula/Detectors/SimpleNurminenDetectionAlgorithm.cs
+++ b/Tabula/Detectors/SimpleNurminenDetectionAlgorithm.cs
@@ -230,7 +230,7 @@ namespace Tabula.Detectors
 
             bool foundTable;
 
-            do
+            //    do
             {
                 foundTable = false;
 
@@ -282,7 +282,10 @@ namespace Tabula.Detectors
                         tableAreas.Add(table);
                     }
                 }
-            } while (foundTable);
+            // removed following line. It's unclear how this code exit's the loop. When a table is found,
+            // there is nothing to advance to the next set of criteria, so a table will always be found.
+            // } while (foundTable);
+            }   
 
             // create a set of our current tables that will eliminate duplicate tables
             SortedSet<TableRectangle> tableSet = new SortedSet<TableRectangle>(new TreeSetComparer());


### PR DESCRIPTION
Investigating hangs on detecting regions in the SimpleNurminenAlgorithm.

See sample project [mikelor/tabulate](https://github.com/mikelor/tabulate) for sample PDFs and code.

Issue seems to be an infinite loop in the Detect Method [here](https://github.com/BobLd/tabula-sharp/blob/b29d4f85141d575d110ecb82bb544b2acf07713d/Tabula/Detectors/SimpleNurminenDetectionAlgorithm.cs#L233)

            // removed following line. It's unclear how this code exit's the loop. When a table is found,
            // there is nothing to advance to the next set of criteria, so a table will always be found.
            // } while (foundTable);