### PR TITLE
Fix for Issue 44: BasicExtractionAlgorithm Extract(PageArea page, IReadOnlyList<float> verticalRulingPositions) failing

### DIFF
--- a/Tabula/Extractors/BasicExtractionAlgorithm.cs
+++ b/Tabula/Extractors/BasicExtractionAlgorithm.cs
@@ -39,7 +39,7 @@ namespace Tabula.Extractors
             List<Ruling> verticalRulings = new List<Ruling>(verticalRulingPositions.Count);
             foreach (float p in verticalRulingPositions)
             {
-                verticalRulings.Add(new Ruling(page.Height, p, 0.0f, page.Height));
+                verticalRulings.Add(new Ruling(page.Bottom, p, 0.0f, page.Height));
             }
             this.verticalRulings = verticalRulings;
             return this.Extract(page);


### PR DESCRIPTION
When creating the Rulings from the passed verticalRulingPositions array, first parameter of the constructor should be the bottom, while before the page height was passed.